### PR TITLE
feat: cost display currency (CNY) with USD/CNY toggle and live-rate refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project are documented here. The format follows [Kee
   the peer is now marked optional).
 - Docs: document uninstall/cleanup steps in the README.
 
+## [Unreleased]
+
 ### Added
 
 - Cost display currency: `config.currency` (`'usd'` default, `'cny'`) and `config.cnyPerUsd`
@@ -23,6 +25,10 @@ All notable changes to this project are documented here. The format follows [Kee
 - A USD/CNY toggle in the cost-estimate section: switching updates every cost figure in the
   indicator and dashboard immediately, and the choice is remembered in the browser
   (`localStorage`), overriding the config default.
+- A rate-refresh control in the cost-estimate section: it fetches the latest USD→CNY rate
+  through a new same-origin host proxy route (`/dsh-usage-chart/rate`; source configurable
+  via `config.fxUrl`, default open.er-api.com), re-estimates CNY costs immediately, and
+  reports the fetch time; failures keep the previous rate and are reported inline.
 - `/dsh-usage-chart/meta` host route that serves the display-currency config to the client.
 
 ### Changed
@@ -31,6 +37,13 @@ All notable changes to this project are documented here. The format follows [Kee
   (e.g. `CNY（1 USD ≈ 6.76 CNY）`).
 - Visual probe scripts now scope the chart-mode toggle to the round-usage section, since the
   panel contains a second `duc-view-toggle` group (currency) ahead of it.
+
+### Fixed
+
+- Client slot registration now waits for the `conversation.composer.dock` declaration via
+  `ctx.slots.inject` instead of registering directly. The direct call depends on loader
+  application order and throws `slot "…" is not declared` at boot once other plugins change
+  that order.
 
 ## [0.1.0] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ All notable changes to this project are documented here. The format follows [Kee
   the peer is now marked optional).
 - Docs: document uninstall/cleanup steps in the README.
 
+### Added
+
+- Cost display currency: `config.currency` (`'usd'` default, `'cny'`) and `config.cnyPerUsd`
+  exchange rate (default `6.76`); costs convert at the configured rate and render with `¥`.
+- A USD/CNY toggle in the cost-estimate section: switching updates every cost figure in the
+  indicator and dashboard immediately, and the choice is remembered in the browser
+  (`localStorage`), overriding the config default.
+- `/dsh-usage-chart/meta` host route that serves the display-currency config to the client.
+
+### Changed
+
+- The per-model price note follows the display currency and notes the applied exchange rate
+  (e.g. `CNY（1 USD ≈ 6.76 CNY）`).
+- Visual probe scripts now scope the chart-mode toggle to the round-usage section, since the
+  panel contains a second `duc-view-toggle` group (currency) ahead of it.
+
 ## [0.1.0] - 2026-08-14
 
 ### Added

--- a/scripts/verify-render.mjs
+++ b/scripts/verify-render.mjs
@@ -96,8 +96,13 @@ if (indicatorText !== null) {
     console.log('PANEL:', JSON.stringify({ cells, balanceText, barRectCount, legend, notes, chartControls, currentBandCount, currentBandGeometry, errText }, null, 2))
     await page.screenshot({ path: join(artifacts, '2-panel.png') })
 
-    // ── 构成视图 + 悬浮详情（按钮文案随语言变化，按位置取第二个） ──
-    const ratioButton = page.locator('.duc-view-toggle button').nth(1)
+    // ── 构成视图 + 悬浮详情（按钮文案随语言变化，按图表区 aria-label 定位） ──
+    // 面板现有两组 .duc-view-toggle（成本币种 / 图表视图），必须限定在图表组内取第二个按钮。
+    const ratioButton = page
+      .locator('.duc-view-toggle[aria-label="图表显示方式"], .duc-view-toggle[aria-label="Chart display"]')
+      .first()
+      .locator('button')
+      .nth(1)
     if (await ratioButton.count()) {
       await ratioButton.click()
       const ratioHeights = await page.$$eval('.duc-chart-turn', (groups) => groups.map((group) => {

--- a/scripts/verify-render.mjs
+++ b/scripts/verify-render.mjs
@@ -97,7 +97,6 @@ if (indicatorText !== null) {
     await page.screenshot({ path: join(artifacts, '2-panel.png') })
 
     // ── 构成视图 + 悬浮详情（按钮文案随语言变化，按图表区 aria-label 定位） ──
-    // 面板现有两组 .duc-view-toggle（成本币种 / 图表视图），必须限定在图表组内取第二个按钮。
     const ratioButton = page
       .locator('.duc-view-toggle[aria-label="图表显示方式"], .duc-view-toggle[aria-label="Chart display"]')
       .first()

--- a/src/client/UsageIndicator.tsx
+++ b/src/client/UsageIndicator.tsx
@@ -4,8 +4,9 @@
  */
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { TokenUsageBuckets } from '../pricing.ts'
-import { billedInputTokens, cacheHitPercent, estimateCost, formatTokens, formatUsd } from '../pricing.ts'
+import { billedInputTokens, cacheHitPercent, estimateCost, formatMoney, formatTokens } from '../pricing.ts'
 import { currencySymbol, useBalance } from './balance.ts'
+import { useDisplayCurrency } from './currency.ts'
 import type { TurnUsage } from './charts.tsx'
 import { getUiCopy, useUiLocale } from './i18n.ts'
 import { UsagePanel } from './UsagePanel.tsx'
@@ -111,6 +112,7 @@ export function UsageIndicator(props: DockUsageProps): JSX.Element | null {
   const { useSession, useProjection, sessionId } = props
   const locale = useUiLocale()
   const copy = getUiCopy(locale)
+  const { currency, cnyPerUsd } = useDisplayCurrency()
   const [expanded, setExpanded] = useState(false)
   const rootRef = useRef<HTMLDivElement | null>(null)
   const toggleRef = useRef<HTMLButtonElement | null>(null)
@@ -182,7 +184,7 @@ export function UsageIndicator(props: DockUsageProps): JSX.Element | null {
     parts.push({ key: 'output', text: `${copy.output} ${formatTokens(totals.outputTokens)}` })
     if (cacheHit !== null) parts.push({ key: 'cache', text: `${copy.cache} ${cacheHit}%` })
   }
-  if (cost !== undefined) parts.push({ key: 'cost', text: `${copy.cost} ${cost.estimated ? '≈' : ''}${formatUsd(cost.usd)}`, estimated: true })
+  if (cost !== undefined) parts.push({ key: 'cost', text: `${copy.cost} ${cost.estimated ? '≈' : ''}${formatMoney(cost.usd, currency, cnyPerUsd)}`, estimated: true })
   if (model !== undefined) parts.push({ key: 'model', text: model.replace(/^deepseek-/, '') })
 
   const balanceLabel = balanceStatus === 'loading' || (balanceStatus === 'ok' && balance === undefined)

--- a/src/client/UsagePanel.tsx
+++ b/src/client/UsagePanel.tsx
@@ -61,7 +61,6 @@ export function UsagePanel(props: UsagePanelProps): JSX.Element {
   const occupancy = occupancyPercent(pressure)
   const cacheHit = cacheHitPercent(totals)
   const hasTokens = billedInputTokens(totals) > 0 || totals.outputTokens > 0
-  // 价格说明：CNY 模式下显示换算后的刊例价与所用汇率。
   const currencySuffix = currency === 'cny' ? `CNY（1 USD ≈ ${cnyPerUsd} CNY）` : 'USD'
 
   const onRefreshRate = async (): Promise<void> => {

--- a/src/client/UsagePanel.tsx
+++ b/src/client/UsagePanel.tsx
@@ -7,8 +7,9 @@
  */
 import { useMemo, useState } from 'react'
 import type { TokenUsageBuckets } from '../pricing.ts'
-import { billedInputTokens, cacheHitPercent, estimateCost, formatTokens, formatUsd, pricingFor } from '../pricing.ts'
+import { billedInputTokens, cacheHitPercent, estimateCost, formatMoney, formatPricePerM, formatTokens, pricingFor } from '../pricing.ts'
 import { currencySymbol, type BalanceData, type BalanceStatus } from './balance.ts'
+import { setDisplayCurrency, useDisplayCurrency } from './currency.ts'
 import { HStack, Legend, SEGMENT_COLORS, tokenLegend, TurnBars, type TurnChartMode, type TurnUsage } from './charts.tsx'
 import { getUiCopy, type UiLocale } from './i18n.ts'
 import { useSessionUsage } from './usage-api.ts'
@@ -46,6 +47,7 @@ export function UsagePanel(props: UsagePanelProps): JSX.Element {
     balanceStatus: status, balanceData: data, loadBalance: load,
   } = props
   const copy = getUiCopy(locale)
+  const { currency, cnyPerUsd } = useDisplayCurrency()
 
   const usage = useSessionUsage(sessionId)
 
@@ -58,6 +60,8 @@ export function UsagePanel(props: UsagePanelProps): JSX.Element {
   const occupancy = occupancyPercent(pressure)
   const cacheHit = cacheHitPercent(totals)
   const hasTokens = billedInputTokens(totals) > 0 || totals.outputTokens > 0
+  // 价格说明：CNY 模式下显示换算后的刊例价与所用汇率。
+  const currencySuffix = currency === 'cny' ? `CNY（1 USD ≈ ${cnyPerUsd} CNY）` : 'USD'
 
   const balance = data?.balances?.[0]
 
@@ -103,11 +107,27 @@ export function UsagePanel(props: UsagePanelProps): JSX.Element {
       <section className="duc-section">
         <div className="duc-section-head">
           <h4>{copy.costEstimate}</h4>
-          <strong className="duc-section-value">≈ {formatUsd(cost.usd)}</strong>
+          <div className="duc-chart-actions">
+            <div className="duc-view-toggle" role="group" aria-label={copy.currencyToggleLabel}>
+              <button
+                type="button"
+                title={copy.currencyToggleUsdTitle}
+                aria-pressed={currency === 'usd'}
+                onClick={() => setDisplayCurrency('usd')}
+              >$ USD</button>
+              <button
+                type="button"
+                title={copy.currencyToggleCnyTitle}
+                aria-pressed={currency === 'cny'}
+                onClick={() => setDisplayCurrency('cny')}
+              >¥ CNY</button>
+            </div>
+            <strong className="duc-section-value">≈ {formatMoney(cost.usd, currency, cnyPerUsd)}</strong>
+          </div>
         </div>
         <div className="duc-cost-split">
-          <span><i style={{ background: SEGMENT_COLORS.miss }} />{copy.inputCost} <b>{formatUsd(inputCost)}</b></span>
-          <span><i style={{ background: SEGMENT_COLORS.output }} />{copy.outputCost} <b>{formatUsd(outputCost)}</b></span>
+          <span><i style={{ background: SEGMENT_COLORS.miss }} />{copy.inputCost} <b>{formatMoney(inputCost, currency, cnyPerUsd)}</b></span>
+          <span><i style={{ background: SEGMENT_COLORS.output }} />{copy.outputCost} <b>{formatMoney(outputCost, currency, cnyPerUsd)}</b></span>
         </div>
         <HStack
           segments={[
@@ -115,7 +135,12 @@ export function UsagePanel(props: UsagePanelProps): JSX.Element {
             { label: copy.outputCost, value: outputCost, color: SEGMENT_COLORS.output },
           ]}
         />
-        <div className="duc-note">{copy.pricingNote(pricing.pricing.cacheMissInput, pricing.pricing.cacheHitInput, pricing.pricing.output)}</div>
+        <div className="duc-note">{copy.pricingNote(
+          formatPricePerM(pricing.pricing.cacheMissInput, currency, cnyPerUsd),
+          formatPricePerM(pricing.pricing.cacheHitInput, currency, cnyPerUsd),
+          formatPricePerM(pricing.pricing.output, currency, cnyPerUsd),
+          currencySuffix,
+        )}</div>
       </section>
 
       <section className="duc-section">

--- a/src/client/UsagePanel.tsx
+++ b/src/client/UsagePanel.tsx
@@ -9,7 +9,7 @@ import { useMemo, useState } from 'react'
 import type { TokenUsageBuckets } from '../pricing.ts'
 import { billedInputTokens, cacheHitPercent, estimateCost, formatMoney, formatPricePerM, formatTokens, pricingFor } from '../pricing.ts'
 import { currencySymbol, type BalanceData, type BalanceStatus } from './balance.ts'
-import { setDisplayCurrency, useDisplayCurrency } from './currency.ts'
+import { refreshLiveRate, setDisplayCurrency, useDisplayCurrency } from './currency.ts'
 import { HStack, Legend, SEGMENT_COLORS, tokenLegend, TurnBars, type TurnChartMode, type TurnUsage } from './charts.tsx'
 import { getUiCopy, type UiLocale } from './i18n.ts'
 import { useSessionUsage } from './usage-api.ts'
@@ -42,12 +42,13 @@ function occupancyPercent(pressure: ContextPressureView | undefined): number | n
 
 export function UsagePanel(props: UsagePanelProps): JSX.Element {
   const [chartMode, setChartMode] = useState<TurnChartMode>('absolute')
+  const [rateStatus, setRateStatus] = useState<'idle' | 'loading' | 'ok' | 'error'>('idle')
   const {
     sessionId, locale, totals, model, observedTurns, pressure,
     balanceStatus: status, balanceData: data, loadBalance: load,
   } = props
   const copy = getUiCopy(locale)
-  const { currency, cnyPerUsd } = useDisplayCurrency()
+  const { currency, cnyPerUsd, rateFetchedAt } = useDisplayCurrency()
 
   const usage = useSessionUsage(sessionId)
 
@@ -62,6 +63,12 @@ export function UsagePanel(props: UsagePanelProps): JSX.Element {
   const hasTokens = billedInputTokens(totals) > 0 || totals.outputTokens > 0
   // 价格说明：CNY 模式下显示换算后的刊例价与所用汇率。
   const currencySuffix = currency === 'cny' ? `CNY（1 USD ≈ ${cnyPerUsd} CNY）` : 'USD'
+
+  const onRefreshRate = async (): Promise<void> => {
+    setRateStatus('loading')
+    const result = await refreshLiveRate()
+    setRateStatus(result === 'ok' ? 'ok' : 'error')
+  }
 
   const balance = data?.balances?.[0]
 
@@ -122,6 +129,13 @@ export function UsagePanel(props: UsagePanelProps): JSX.Element {
                 onClick={() => setDisplayCurrency('cny')}
               >¥ CNY</button>
             </div>
+            <button
+              type="button"
+              className="duc-refresh"
+              disabled={rateStatus === 'loading'}
+              title={copy.refreshRateTitle}
+              onClick={() => void onRefreshRate()}
+            >{rateStatus === 'loading' ? copy.refreshingRate : copy.refreshRate}</button>
             <strong className="duc-section-value">≈ {formatMoney(cost.usd, currency, cnyPerUsd)}</strong>
           </div>
         </div>
@@ -141,6 +155,11 @@ export function UsagePanel(props: UsagePanelProps): JSX.Element {
           formatPricePerM(pricing.pricing.output, currency, cnyPerUsd),
           currencySuffix,
         )}</div>
+        {currency === 'cny' && rateStatus !== 'idle' && (
+          <div className="duc-note">{rateStatus === 'ok'
+            ? copy.rateLive(cnyPerUsd, new Date(rateFetchedAt ?? Date.now()).toLocaleTimeString())
+            : copy.rateError(cnyPerUsd)}</div>
+        )}
       </section>
 
       <section className="duc-section">

--- a/src/client/currency.ts
+++ b/src/client/currency.ts
@@ -4,6 +4,8 @@
  *    作为默认值（无用户选择时生效）；
  *  - 用户可在用量面板中切换 USD/CNY，选择写入 localStorage
  *    （`dsh-usage-chart:currency`），在本浏览器中记住并覆盖配置默认值；
+ *  - 「刷新汇率」经宿主 `/dsh-usage-chart/rate` 拉取实时汇率，覆盖当前汇率
+ *    并在本次会话内生效（不落盘，避免陈旧汇率被长期记住）；
  *  - 组件经 useDisplayCurrency() 读取，切换后全界面实时更新。
  */
 import { useSyncExternalStore } from 'react'
@@ -12,13 +14,19 @@ import { DEFAULT_CNY_PER_USD, type DisplayCurrency } from '../pricing.ts'
 export interface DisplayMeta {
   currency: DisplayCurrency
   cnyPerUsd: number
+  /** 汇率来源：'config'（配置默认）或 'live'（本次会话内刷新所得）。 */
+  rateSource?: 'config' | 'live'
+  /** 实时汇率获取时间（epoch ms；仅 rateSource === 'live' 时有意义）。 */
+  rateFetchedAt?: number
 }
 
+export type RateRefreshResult = 'ok' | 'request-failed' | 'bad-response'
+
 const STORAGE_KEY = 'dsh-usage-chart:currency'
-const DEFAULT_META: DisplayMeta = { currency: 'usd', cnyPerUsd: DEFAULT_CNY_PER_USD }
+const DEFAULT_META: DisplayMeta = { currency: 'usd', cnyPerUsd: DEFAULT_CNY_PER_USD, rateSource: 'config' }
 
 let meta: DisplayMeta = DEFAULT_META
-/** 用户是否已在界面中手动选择过（此后 meta 拉取不再覆盖）。 */
+/** 用户是否已在界面中手动选择过（此后 meta 拉取不再覆盖币种）。 */
 let userChosen = false
 const listeners = new Set<() => void>()
 
@@ -86,19 +94,44 @@ export async function fetchDisplayMeta(): Promise<void> {
         ? body.cnyPerUsd
         : DEFAULT_CNY_PER_USD
     if (userChosen) {
-      // 只更新汇率，币种保留用户选择。
-      if (meta.cnyPerUsd !== cnyPerUsd) {
+      // 只更新汇率，币种保留用户选择；实时汇率（本会话内刷新）优先于配置默认。
+      if (meta.cnyPerUsd !== cnyPerUsd && meta.rateSource !== 'live') {
         meta = { ...meta, cnyPerUsd }
         notify()
       }
       return
     }
-    if (meta.currency !== currency || meta.cnyPerUsd !== cnyPerUsd) {
+    if ((meta.currency !== currency || meta.cnyPerUsd !== cnyPerUsd) && meta.rateSource !== 'live') {
       meta = { currency, cnyPerUsd }
       notify()
     }
   } catch {
     // 忽略：保持默认（usd）。
+  }
+}
+
+/**
+ * 应用实时汇率：覆盖当前汇率并标注来源与获取时间。
+ * 仅在本次会话内生效（不写 localStorage，避免陈旧汇率被长期记住）。
+ */
+export function setLiveRate(rate: number, fetchedAt: number): void {
+  if (meta.currency === 'cny' && meta.cnyPerUsd === rate && meta.rateSource === 'live' && meta.rateFetchedAt === fetchedAt) return
+  meta = { ...meta, cnyPerUsd: rate, rateSource: 'live', rateFetchedAt: fetchedAt }
+  notify()
+}
+
+/** 经宿主代理拉取实时汇率；成功返回 'ok'，失败返回结构化原因（不改动当前汇率）。 */
+export async function refreshLiveRate(): Promise<RateRefreshResult> {
+  try {
+    const res = await fetch('/dsh-usage-chart/rate', { headers: { Accept: 'application/json' } })
+    const body = (await res.json()) as { ok?: boolean; rate?: unknown; fetchedAt?: unknown; reason?: string }
+    if (body.ok === true && typeof body.rate === 'number' && Number.isFinite(body.rate) && body.rate > 0) {
+      setLiveRate(body.rate, typeof body.fetchedAt === 'number' ? body.fetchedAt : Date.now())
+      return 'ok'
+    }
+    return body.reason === 'bad-response' ? 'bad-response' : 'request-failed'
+  } catch {
+    return 'request-failed'
   }
 }
 

--- a/src/client/currency.ts
+++ b/src/client/currency.ts
@@ -1,22 +1,10 @@
-/**
- * 客户端成本显示币种（本地定制）：
- *  - 宿主在 `/dsh-usage-chart/meta` 下发 config.currency / config.cnyPerUsd，
- *    作为默认值（无用户选择时生效）；
- *  - 用户可在用量面板中切换 USD/CNY，选择写入 localStorage
- *    （`dsh-usage-chart:currency`），在本浏览器中记住并覆盖配置默认值；
- *  - 「刷新汇率」经宿主 `/dsh-usage-chart/rate` 拉取实时汇率，覆盖当前汇率
- *    并在本次会话内生效（不落盘，避免陈旧汇率被长期记住）；
- *  - 组件经 useDisplayCurrency() 读取，切换后全界面实时更新。
- */
 import { useSyncExternalStore } from 'react'
 import { DEFAULT_CNY_PER_USD, type DisplayCurrency } from '../pricing.ts'
 
 export interface DisplayMeta {
   currency: DisplayCurrency
   cnyPerUsd: number
-  /** 汇率来源：'config'（配置默认）或 'live'（本次会话内刷新所得）。 */
   rateSource?: 'config' | 'live'
-  /** 实时汇率获取时间（epoch ms；仅 rateSource === 'live' 时有意义）。 */
   rateFetchedAt?: number
 }
 
@@ -26,7 +14,6 @@ const STORAGE_KEY = 'dsh-usage-chart:currency'
 const DEFAULT_META: DisplayMeta = { currency: 'usd', cnyPerUsd: DEFAULT_CNY_PER_USD, rateSource: 'config' }
 
 let meta: DisplayMeta = DEFAULT_META
-/** 用户是否已在界面中手动选择过（此后 meta 拉取不再覆盖币种）。 */
 let userChosen = false
 const listeners = new Set<() => void>()
 
@@ -34,7 +21,6 @@ function notify(): void {
   for (const listener of [...listeners]) listener()
 }
 
-/** 读取本浏览器记住的币种选择（无效值返回 null）。 */
 function storedCurrency(): DisplayCurrency | null {
   try {
     const value = typeof localStorage === 'undefined' ? null : localStorage.getItem(STORAGE_KEY)
@@ -44,12 +30,10 @@ function storedCurrency(): DisplayCurrency | null {
   }
 }
 
-/** 读取当前显示币种快照（订阅源的 getSnapshot）。 */
 export function getDisplayMeta(): DisplayMeta {
   return meta
 }
 
-/** 订阅显示币种变化（返回退订函数）。 */
 export function subscribeDisplayMeta(listener: () => void): () => void {
   listeners.add(listener)
   return () => {
@@ -57,15 +41,10 @@ export function subscribeDisplayMeta(listener: () => void): () => void {
   }
 }
 
-/** 组件读当前显示币种与汇率。 */
 export function useDisplayCurrency(): DisplayMeta {
   return useSyncExternalStore(subscribeDisplayMeta, getDisplayMeta)
 }
 
-/**
- * 用户切换币种：更新 store 并写入 localStorage。
- * 汇率（cnyPerUsd）保持宿主配置值不变。
- */
 export function setDisplayCurrency(currency: DisplayCurrency): void {
   userChosen = true
   if (meta.currency === currency) return
@@ -73,15 +52,11 @@ export function setDisplayCurrency(currency: DisplayCurrency): void {
   try {
     localStorage.setItem(STORAGE_KEY, currency)
   } catch {
-    // localStorage 不可用时仅本次会话内生效。
+    // ignore
   }
   notify()
 }
 
-/**
- * 从宿主 meta 路由拉取默认币种与汇率。
- * 用户已手动选择过时不再覆盖（本地选择优先于配置默认值）。
- */
 export async function fetchDisplayMeta(): Promise<void> {
   try {
     const res = await fetch('/dsh-usage-chart/meta', { headers: { Accept: 'application/json' } })
@@ -94,7 +69,6 @@ export async function fetchDisplayMeta(): Promise<void> {
         ? body.cnyPerUsd
         : DEFAULT_CNY_PER_USD
     if (userChosen) {
-      // 只更新汇率，币种保留用户选择；实时汇率（本会话内刷新）优先于配置默认。
       if (meta.cnyPerUsd !== cnyPerUsd && meta.rateSource !== 'live') {
         meta = { ...meta, cnyPerUsd }
         notify()
@@ -106,21 +80,16 @@ export async function fetchDisplayMeta(): Promise<void> {
       notify()
     }
   } catch {
-    // 忽略：保持默认（usd）。
+    // ignore
   }
 }
 
-/**
- * 应用实时汇率：覆盖当前汇率并标注来源与获取时间。
- * 仅在本次会话内生效（不写 localStorage，避免陈旧汇率被长期记住）。
- */
 export function setLiveRate(rate: number, fetchedAt: number): void {
   if (meta.currency === 'cny' && meta.cnyPerUsd === rate && meta.rateSource === 'live' && meta.rateFetchedAt === fetchedAt) return
   meta = { ...meta, cnyPerUsd: rate, rateSource: 'live', rateFetchedAt: fetchedAt }
   notify()
 }
 
-/** 经宿主代理拉取实时汇率；成功返回 'ok'，失败返回结构化原因（不改动当前汇率）。 */
 export async function refreshLiveRate(): Promise<RateRefreshResult> {
   try {
     const res = await fetch('/dsh-usage-chart/rate', { headers: { Accept: 'application/json' } })
@@ -135,10 +104,6 @@ export async function refreshLiveRate(): Promise<RateRefreshResult> {
   }
 }
 
-/**
- * 插件 apply 时调用：先读本浏览器记住的选择（立即生效），
- * 再拉取宿主配置作为兜底默认值。
- */
 export function initDisplayMeta(): void {
   const stored = storedCurrency()
   if (stored !== null) {

--- a/src/client/currency.ts
+++ b/src/client/currency.ts
@@ -1,0 +1,116 @@
+/**
+ * 客户端成本显示币种（本地定制）：
+ *  - 宿主在 `/dsh-usage-chart/meta` 下发 config.currency / config.cnyPerUsd，
+ *    作为默认值（无用户选择时生效）；
+ *  - 用户可在用量面板中切换 USD/CNY，选择写入 localStorage
+ *    （`dsh-usage-chart:currency`），在本浏览器中记住并覆盖配置默认值；
+ *  - 组件经 useDisplayCurrency() 读取，切换后全界面实时更新。
+ */
+import { useSyncExternalStore } from 'react'
+import { DEFAULT_CNY_PER_USD, type DisplayCurrency } from '../pricing.ts'
+
+export interface DisplayMeta {
+  currency: DisplayCurrency
+  cnyPerUsd: number
+}
+
+const STORAGE_KEY = 'dsh-usage-chart:currency'
+const DEFAULT_META: DisplayMeta = { currency: 'usd', cnyPerUsd: DEFAULT_CNY_PER_USD }
+
+let meta: DisplayMeta = DEFAULT_META
+/** 用户是否已在界面中手动选择过（此后 meta 拉取不再覆盖）。 */
+let userChosen = false
+const listeners = new Set<() => void>()
+
+function notify(): void {
+  for (const listener of [...listeners]) listener()
+}
+
+/** 读取本浏览器记住的币种选择（无效值返回 null）。 */
+function storedCurrency(): DisplayCurrency | null {
+  try {
+    const value = typeof localStorage === 'undefined' ? null : localStorage.getItem(STORAGE_KEY)
+    return value === 'cny' || value === 'usd' ? value : null
+  } catch {
+    return null
+  }
+}
+
+/** 读取当前显示币种快照（订阅源的 getSnapshot）。 */
+export function getDisplayMeta(): DisplayMeta {
+  return meta
+}
+
+/** 订阅显示币种变化（返回退订函数）。 */
+export function subscribeDisplayMeta(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** 组件读当前显示币种与汇率。 */
+export function useDisplayCurrency(): DisplayMeta {
+  return useSyncExternalStore(subscribeDisplayMeta, getDisplayMeta)
+}
+
+/**
+ * 用户切换币种：更新 store 并写入 localStorage。
+ * 汇率（cnyPerUsd）保持宿主配置值不变。
+ */
+export function setDisplayCurrency(currency: DisplayCurrency): void {
+  userChosen = true
+  if (meta.currency === currency) return
+  meta = { ...meta, currency }
+  try {
+    localStorage.setItem(STORAGE_KEY, currency)
+  } catch {
+    // localStorage 不可用时仅本次会话内生效。
+  }
+  notify()
+}
+
+/**
+ * 从宿主 meta 路由拉取默认币种与汇率。
+ * 用户已手动选择过时不再覆盖（本地选择优先于配置默认值）。
+ */
+export async function fetchDisplayMeta(): Promise<void> {
+  try {
+    const res = await fetch('/dsh-usage-chart/meta', { headers: { Accept: 'application/json' } })
+    if (!res.ok) return
+    const body = (await res.json()) as { ok?: boolean; currency?: string; cnyPerUsd?: number }
+    if (body.ok !== true) return
+    const currency: DisplayCurrency = body.currency === 'cny' ? 'cny' : 'usd'
+    const cnyPerUsd =
+      typeof body.cnyPerUsd === 'number' && Number.isFinite(body.cnyPerUsd) && body.cnyPerUsd > 0
+        ? body.cnyPerUsd
+        : DEFAULT_CNY_PER_USD
+    if (userChosen) {
+      // 只更新汇率，币种保留用户选择。
+      if (meta.cnyPerUsd !== cnyPerUsd) {
+        meta = { ...meta, cnyPerUsd }
+        notify()
+      }
+      return
+    }
+    if (meta.currency !== currency || meta.cnyPerUsd !== cnyPerUsd) {
+      meta = { currency, cnyPerUsd }
+      notify()
+    }
+  } catch {
+    // 忽略：保持默认（usd）。
+  }
+}
+
+/**
+ * 插件 apply 时调用：先读本浏览器记住的选择（立即生效），
+ * 再拉取宿主配置作为兜底默认值。
+ */
+export function initDisplayMeta(): void {
+  const stored = storedCurrency()
+  if (stored !== null) {
+    userChosen = true
+    meta = { ...meta, currency: stored }
+  }
+  void fetchDisplayMeta()
+}

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -43,6 +43,11 @@ export interface UiCopy {
   currencyToggleLabel: string
   currencyToggleUsdTitle: string
   currencyToggleCnyTitle: string
+  refreshRate: string
+  refreshingRate: string
+  refreshRateTitle: string
+  rateLive: (rate: number, time: string) => string
+  rateError: (rate: number) => string
   toppedUp: string
   granted: string
   noApiKey: string
@@ -81,6 +86,9 @@ const COPY: Record<UiLocale, UiCopy> = {
     accountBalance: '账户余额', loadingBalance: '正在查询账户余额', balanceEnough: '余额充足', balanceLow: '余额不足',
     currency: '币种', currencyToggleLabel: '成本显示币种',
     currencyToggleUsdTitle: '成本按美元（USD）显示，选择会在本浏览器中记住', currencyToggleCnyTitle: '成本按人民币（CNY）显示，选择会在本浏览器中记住',
+    refreshRate: '刷新汇率', refreshingRate: '获取中…', refreshRateTitle: '获取最新汇率并重新估算（本次会话有效）',
+    rateLive: (rate, time) => `实时汇率已更新：1 USD = ${rate} CNY（${time} 获取，本次会话有效）`,
+    rateError: (rate) => `实时汇率获取失败，沿用 1 USD = ${rate} CNY。`,
     toppedUp: '充值', granted: '赠送', noApiKey: '未配置 DEEPSEEK_API_KEY（或插件 config.apiKey），无法查询余额。',
     balanceError: (message) => `余额查询失败：${message}`, unknown: '未知错误', retry: '重试', balanceIdle: '点击输入框下方的余额信息即可查询。',
     historySource: (truncated) => `来自会话日志，完整历史${truncated ? '，图表显示最近 12 轮' : ''}`,
@@ -105,6 +113,9 @@ const COPY: Record<UiLocale, UiCopy> = {
     accountBalance: 'Account balance', loadingBalance: 'Loading account balance', balanceEnough: 'Available', balanceLow: 'Insufficient',
     currency: 'Currency', currencyToggleLabel: 'Cost display currency',
     currencyToggleUsdTitle: 'Show cost in USD; remembered in this browser', currencyToggleCnyTitle: 'Show cost in CNY; remembered in this browser',
+    refreshRate: 'Refresh rate', refreshingRate: 'Fetching…', refreshRateTitle: 'Fetch the latest exchange rate and re-estimate (valid for this session)',
+    rateLive: (rate, time) => `Live rate updated: 1 USD = ${rate} CNY (fetched at ${time}, valid for this session)`,
+    rateError: (rate) => `Could not fetch the live rate; keeping 1 USD = ${rate} CNY.`,
     toppedUp: 'Topped up', granted: 'Granted', noApiKey: 'DEEPSEEK_API_KEY (or plugin config.apiKey) is not configured, so the balance cannot be queried.',
     balanceError: (message) => `Balance query failed: ${message}`, unknown: 'Unknown error', retry: 'Retry', balanceIdle: 'Select the balance below the composer to query it.',
     historySource: (truncated) => `Full history from the session log${truncated ? '; showing the latest 12 rounds' : ''}`,

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -23,7 +23,7 @@ export interface UiCopy {
   costEstimate: string
   inputCost: string
   outputCost: string
-  pricingNote: (miss: number, hit: number, output: number) => string
+  pricingNote: (miss: string, hit: string, output: string, currencySuffix: string) => string
   roundUsage: string
   chartDisplay: string
   totalMode: string
@@ -40,6 +40,9 @@ export interface UiCopy {
   balanceEnough: string
   balanceLow: string
   currency: string
+  currencyToggleLabel: string
+  currencyToggleUsdTitle: string
+  currencyToggleCnyTitle: string
   toppedUp: string
   granted: string
   noApiKey: string
@@ -70,13 +73,15 @@ const COPY: Record<UiLocale, UiCopy> = {
     usageDetails: '会话用量详情', sessionUsage: '会话用量', billedInput: '计费输入', cacheHit: '缓存命中', contextUsage: '上下文占用', unavailable: '暂无',
     sessionEmpty: '发送消息后，这里会显示当前会话的 Token 用量。',
     costEstimate: '成本估算', inputCost: '输入', outputCost: '输出',
-    pricingNote: (miss, hit, output) => `官方刊例价：未命中输入 ${miss}/1M，命中输入 ${hit}/1M，输出 ${output}/1M USD。估算值，不代表官方账单。`,
+    pricingNote: (miss, hit, output, currencySuffix) => `官方刊例价：未命中输入 ${miss}/1M，命中输入 ${hit}/1M，输出 ${output}/1M ${currencySuffix}。估算值，不代表官方账单。`,
     roundUsage: '轮次用量', chartDisplay: '图表显示方式', totalMode: '总量', compositionMode: '构成',
     totalModeTitle: '按实际 Token 总量比较各轮消耗', compositionModeTitle: '将每轮统一为 100%，比较 Token 构成', refresh: '刷新',
     roundExplainer: '每根柱代表一轮提问与回答', totalExplainer: '柱高表示本轮 Token 总量', compositionExplainer: '每根柱统一为 100%，仅比较 Token 构成',
     roundEmpty: '发送消息后，这里会按轮次绘制 Token 用量。',
     accountBalance: '账户余额', loadingBalance: '正在查询账户余额', balanceEnough: '余额充足', balanceLow: '余额不足',
-    currency: '币种', toppedUp: '充值', granted: '赠送', noApiKey: '未配置 DEEPSEEK_API_KEY（或插件 config.apiKey），无法查询余额。',
+    currency: '币种', currencyToggleLabel: '成本显示币种',
+    currencyToggleUsdTitle: '成本按美元（USD）显示，选择会在本浏览器中记住', currencyToggleCnyTitle: '成本按人民币（CNY）显示，选择会在本浏览器中记住',
+    toppedUp: '充值', granted: '赠送', noApiKey: '未配置 DEEPSEEK_API_KEY（或插件 config.apiKey），无法查询余额。',
     balanceError: (message) => `余额查询失败：${message}`, unknown: '未知错误', retry: '重试', balanceIdle: '点击输入框下方的余额信息即可查询。',
     historySource: (truncated) => `来自会话日志，完整历史${truncated ? '，图表显示最近 12 轮' : ''}`,
     historyFallback: (error) => `宿主历史不可用（${error}），已回退到本页观测增量。`, historyLoading: '加载会话日志历史…',
@@ -92,13 +97,15 @@ const COPY: Record<UiLocale, UiCopy> = {
     usageDetails: 'Session usage details', sessionUsage: 'Session usage', billedInput: 'Billed input', cacheHit: 'Cache hit', contextUsage: 'Context used', unavailable: 'N/A',
     sessionEmpty: 'Token usage will appear after you send a message.',
     costEstimate: 'Estimated cost', inputCost: 'Input', outputCost: 'Output',
-    pricingNote: (miss, hit, output) => `Official list price: cache-miss input ${miss}/1M, cache-hit input ${hit}/1M, output ${output}/1M USD. Estimate only, not an official bill.`,
+    pricingNote: (miss, hit, output, currencySuffix) => `Official list price: cache-miss input ${miss}/1M, cache-hit input ${hit}/1M, output ${output}/1M ${currencySuffix}. Estimate only, not an official bill.`,
     roundUsage: 'Usage by round', chartDisplay: 'Chart display', totalMode: 'Total', compositionMode: 'Mix',
     totalModeTitle: 'Compare rounds by actual Token usage', compositionModeTitle: 'Normalize each round to 100% and compare Token mix', refresh: 'Refresh',
     roundExplainer: 'Each bar represents one prompt and response', totalExplainer: 'Bar height shows total Tokens for the round', compositionExplainer: 'Each bar is normalized to 100% to compare Token mix',
     roundEmpty: 'Per-round Token usage will appear after you send a message.',
     accountBalance: 'Account balance', loadingBalance: 'Loading account balance', balanceEnough: 'Available', balanceLow: 'Insufficient',
-    currency: 'Currency', toppedUp: 'Topped up', granted: 'Granted', noApiKey: 'DEEPSEEK_API_KEY (or plugin config.apiKey) is not configured, so the balance cannot be queried.',
+    currency: 'Currency', currencyToggleLabel: 'Cost display currency',
+    currencyToggleUsdTitle: 'Show cost in USD; remembered in this browser', currencyToggleCnyTitle: 'Show cost in CNY; remembered in this browser',
+    toppedUp: 'Topped up', granted: 'Granted', noApiKey: 'DEEPSEEK_API_KEY (or plugin config.apiKey) is not configured, so the balance cannot be queried.',
     balanceError: (message) => `Balance query failed: ${message}`, unknown: 'Unknown error', retry: 'Retry', balanceIdle: 'Select the balance below the composer to query it.',
     historySource: (truncated) => `Full history from the session log${truncated ? '; showing the latest 12 rounds' : ''}`,
     historyFallback: (error) => `Host history unavailable (${error}); showing usage observed on this page.`, historyLoading: 'Loading session history…',

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -31,7 +31,10 @@ export function apply(ctx: ClientContext): void {
   syncLocale()
   ctx.effect(() => ctx.locale.subscribe(syncLocale), 'dsh-usage-chart: locale subscription')
 
-  ctx.slots.register(
+  // 槽位注册：经 slots.inject 等待父条目（ui-conversation）的 children 表
+  // 声明 'conversation.composer.dock' 后再注册。直接 register 依赖加载顺序，
+  // 其他插件改变应用顺序时会在启动时抛「slot is not declared」。
+  ctx.slots.inject('conversation.composer.dock', () => ctx.slots.register(
     {
       name: 'conversation.composer.dock',
       id: 'dsh-usage-chart',
@@ -39,5 +42,5 @@ export function apply(ctx: ClientContext): void {
       registrant: 'dsh-usage-chart',
     },
     UsageIndicator,
-  )
+  ))
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -20,20 +20,14 @@ export const inject = ['slots', 'locale']
 export function apply(ctx: ClientContext): void {
   injectPluginCss()
 
-  // 成本显示币种（本地定制）：先恢复本浏览器记住的选择，再拉取宿主配置默认值。
   initDisplayMeta()
 
-  // 活动语言：初始取平台快照（含宿主设置与浏览器推导），此后随快照切换。
-  // 注意：locale.subscribe 的监听器无参调用（publish 里 fn()），需自行重读快照。
   const syncLocale = (): void => {
     setUiLocale(ctx.locale.getLocale().active === 'en' ? 'en' : 'zh')
   }
   syncLocale()
   ctx.effect(() => ctx.locale.subscribe(syncLocale), 'dsh-usage-chart: locale subscription')
 
-  // 槽位注册：经 slots.inject 等待父条目（ui-conversation）的 children 表
-  // 声明 'conversation.composer.dock' 后再注册。直接 register 依赖加载顺序，
-  // 其他插件改变应用顺序时会在启动时抛「slot is not declared」。
   ctx.slots.inject('conversation.composer.dock', () => ctx.slots.register(
     {
       name: 'conversation.composer.dock',

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -8,6 +8,7 @@
  */
 import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
 import { UsageIndicator } from './UsageIndicator.tsx'
+import { initDisplayMeta } from './currency.ts'
 import { injectPluginCss } from './styles.ts'
 import { setUiLocale } from './i18n.ts'
 
@@ -18,6 +19,9 @@ export const inject = ['slots', 'locale']
 
 export function apply(ctx: ClientContext): void {
   injectPluginCss()
+
+  // 成本显示币种（本地定制）：先恢复本浏览器记住的选择，再拉取宿主配置默认值。
+  initDisplayMeta()
 
   // 活动语言：初始取平台快照（含宿主设置与浏览器推导），此后随快照切换。
   // 注意：locale.subscribe 的监听器无参调用（publish 里 fn()），需自行重读快照。

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,34 @@
 /**
  * 宿主（Node）半区：dsh-usage-chart
  *
- * 在同源 HTTP 服务上注册两个路由：
+ * 在同源 HTTP 服务上注册三个路由：
  *  - `/dsh-usage-chart/balance` — 代理 DeepSeek 官方 `GET /user/balance`
  *    （浏览器直连会被 CORS 拦截，且 API Key 不应暴露给浏览器）。
  *  - `/dsh-usage-chart/usage`   — 读取会话日志（adapter 上报的完整事件流），
  *    折叠出每轮真实 token 用量（与 token-meter 相同的折叠语义）。
+ *  - `/dsh-usage-chart/meta`    — 下发成本显示币种与汇率配置（本地定制）。
  */
 import type { Context, CredentialsService } from '@deepseek-ai/cordis'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { normalizeCnyPerUsd, normalizeCurrency } from './pricing.ts'
 
 export {
+  DEFAULT_CNY_PER_USD,
   PRICING,
   ZERO_BUCKETS,
   billedInputTokens,
   cacheHitPercent,
   estimateCost,
+  formatMoney,
+  formatPricePerM,
   formatTokens,
   formatUsd,
+  normalizeCnyPerUsd,
+  normalizeCurrency,
   pricingFor,
+  toDisplayAmount,
 } from './pricing.ts'
-export type { ModelPricing, TokenUsageBuckets } from './pricing.ts'
+export type { DisplayCurrency, ModelPricing, TokenUsageBuckets } from './pricing.ts'
 
 export const name = 'dsh-usage-chart'
 
@@ -32,6 +40,10 @@ export interface Config {
   apiKey?: string
   /** 可选：官方 API 基地址。 */
   baseUrl?: string
+  /** 可选（本地定制）：成本显示币种，'usd'（默认）或 'cny'。 */
+  currency?: string
+  /** 可选（本地定制）：currency: 'cny' 时的美元兑人民币汇率，默认 6.76。 */
+  cnyPerUsd?: number
 }
 
 interface BalanceInfo {
@@ -316,6 +328,18 @@ export function apply(ctx: Context, config: Config = {}): void {
     return (process.env.DEEPSEEK_API_KEY ?? '').trim()
   }
   const baseUrl = normalizeBaseUrl(config.baseUrl)
+  const currency = normalizeCurrency(config.currency)
+  const cnyPerUsd = normalizeCnyPerUsd(config.cnyPerUsd)
+
+  // 成本显示币种与汇率（本地定制）：客户端无配置通道，经同源路由下发。
+  ctx.effect(() => ctx.webServer.register({
+    kind: 'exact',
+    path: '/dsh-usage-chart/meta',
+    async handler(req: IncomingMessage, res: ServerResponse) {
+      if (!guardRequest(req, res)) return
+      writeJson(res, 200, { ok: true, currency, cnyPerUsd })
+    },
+  }), 'dsh-usage-chart: meta route')
 
   ctx.effect(() => ctx.webServer.register({
     kind: 'exact',

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,8 @@
  *    （浏览器直连会被 CORS 拦截，且 API Key 不应暴露给浏览器）。
  *  - `/dsh-usage-chart/usage`   — 读取会话日志（adapter 上报的完整事件流），
  *    折叠出每轮真实 token 用量（与 token-meter 相同的折叠语义）。
- *  - `/dsh-usage-chart/meta`    — 下发成本显示币种与汇率配置（本地定制）。
- *  - `/dsh-usage-chart/rate`    — 代理实时 USD→CNY 汇率查询（本地定制）。
+ *  - `/dsh-usage-chart/meta`    — 下发成本显示币种与汇率配置。
+ *  - `/dsh-usage-chart/rate`    — 代理实时 USD→CNY 汇率查询。
  */
 import type { Context, CredentialsService } from '@deepseek-ai/cordis'
 import type { IncomingMessage, ServerResponse } from 'node:http'
@@ -41,12 +41,11 @@ export interface Config {
   apiKey?: string
   /** 可选：官方 API 基地址。 */
   baseUrl?: string
-  /** 可选（本地定制）：成本显示币种，'usd'（默认）或 'cny'。 */
+  /** 可选：成本显示币种，'usd'（默认）或 'cny'。 */
   currency?: string
-  /** 可选（本地定制）：currency: 'cny' 时的美元兑人民币汇率，默认 6.76。 */
+  /** 可选：currency: 'cny' 时的美元兑人民币汇率，默认 6.76。 */
   cnyPerUsd?: number
-  /** 可选（本地定制）：实时汇率数据源 URL（须返回 `{ rates: { CNY: number } }` 结构），
-   *  默认 open.er-api.com；HTTPS 要求与 baseUrl 相同（回环地址允许 HTTP）。 */
+  /** 可选：实时汇率数据源 URL（须返回 `{ rates: { CNY: number } }` 结构），默认 open.er-api.com。 */
   fxUrl?: string
 }
 
@@ -94,7 +93,6 @@ export interface SessionEventLike {
 
 const DEFAULT_BASE_URL = 'https://api.deepseek.com'
 
-/** 实时汇率默认数据源（返回 { result, rates: { CNY } } 结构）。 */
 const DEFAULT_FX_URL = 'https://open.er-api.com/v6/latest/USD'
 
 /**
@@ -308,10 +306,6 @@ async function fetchBalance(apiKey: string, baseUrl: string): Promise<BalanceRes
   }
 }
 
-/**
- * 拉取实时 USD → CNY 汇率（默认 open.er-api.com，可用 config.fxUrl 覆盖）。
- * 任何失败都返回结构化错误，不抛异常；汇率必须为正的有限数值。
- */
 async function fetchLiveRate(fxUrl: string): Promise<{
   ok: boolean
   rate?: number
@@ -386,7 +380,6 @@ export function apply(ctx: Context, config: Config = {}): void {
   const cnyPerUsd = normalizeCnyPerUsd(config.cnyPerUsd)
   const fxUrl = normalizeBaseUrl(config.fxUrl === undefined || config.fxUrl === '' ? DEFAULT_FX_URL : config.fxUrl)
 
-  // 成本显示币种与汇率（本地定制）：客户端无配置通道，经同源路由下发。
   ctx.effect(() => ctx.webServer.register({
     kind: 'exact',
     path: '/dsh-usage-chart/meta',
@@ -396,7 +389,6 @@ export function apply(ctx: Context, config: Config = {}): void {
     },
   }), 'dsh-usage-chart: meta route')
 
-  // 实时汇率（本地定制）：浏览器直连汇率源有 CORS 与可靠性问题，经宿主代理。
   ctx.effect(() => ctx.webServer.register({
     kind: 'exact',
     path: '/dsh-usage-chart/rate',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 /**
  * 宿主（Node）半区：dsh-usage-chart
  *
- * 在同源 HTTP 服务上注册三个路由：
+ * 在同源 HTTP 服务上注册四个路由：
  *  - `/dsh-usage-chart/balance` — 代理 DeepSeek 官方 `GET /user/balance`
  *    （浏览器直连会被 CORS 拦截，且 API Key 不应暴露给浏览器）。
  *  - `/dsh-usage-chart/usage`   — 读取会话日志（adapter 上报的完整事件流），
  *    折叠出每轮真实 token 用量（与 token-meter 相同的折叠语义）。
  *  - `/dsh-usage-chart/meta`    — 下发成本显示币种与汇率配置（本地定制）。
+ *  - `/dsh-usage-chart/rate`    — 代理实时 USD→CNY 汇率查询（本地定制）。
  */
 import type { Context, CredentialsService } from '@deepseek-ai/cordis'
 import type { IncomingMessage, ServerResponse } from 'node:http'
@@ -44,6 +45,9 @@ export interface Config {
   currency?: string
   /** 可选（本地定制）：currency: 'cny' 时的美元兑人民币汇率，默认 6.76。 */
   cnyPerUsd?: number
+  /** 可选（本地定制）：实时汇率数据源 URL（须返回 `{ rates: { CNY: number } }` 结构），
+   *  默认 open.er-api.com；HTTPS 要求与 baseUrl 相同（回环地址允许 HTTP）。 */
+  fxUrl?: string
 }
 
 interface BalanceInfo {
@@ -89,6 +93,9 @@ export interface SessionEventLike {
 }
 
 const DEFAULT_BASE_URL = 'https://api.deepseek.com'
+
+/** 实时汇率默认数据源（返回 { result, rates: { CNY } } 结构）。 */
+const DEFAULT_FX_URL = 'https://open.er-api.com/v6/latest/USD'
 
 /**
  * Normalize and validate the upstream API URL.
@@ -302,6 +309,53 @@ async function fetchBalance(apiKey: string, baseUrl: string): Promise<BalanceRes
 }
 
 /**
+ * 拉取实时 USD → CNY 汇率（默认 open.er-api.com，可用 config.fxUrl 覆盖）。
+ * 任何失败都返回结构化错误，不抛异常；汇率必须为正的有限数值。
+ */
+async function fetchLiveRate(fxUrl: string): Promise<{
+  ok: boolean
+  rate?: number
+  fetchedAt?: number
+  reason?: 'request-failed' | 'bad-response'
+  message?: string
+}> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 8_000)
+  try {
+    const res = await fetch(fxUrl, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    })
+    if (!res.ok) {
+      return {
+        ok: false,
+        reason: 'request-failed',
+        message: `汇率源返回 HTTP ${res.status}`,
+      }
+    }
+    const data = (await res.json()) as { rates?: { CNY?: unknown } }
+    const rate = data.rates?.CNY
+    if (typeof rate !== 'number' || !Number.isFinite(rate) || rate <= 0) {
+      return {
+        ok: false,
+        reason: 'bad-response',
+        message: '汇率源未返回有效的 rates.CNY',
+      }
+    }
+    return { ok: true, rate, fetchedAt: Date.now() }
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'request-failed',
+      message: error instanceof Error ? error.message : String(error),
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
  * 插件入口：注册余额代理路由。
  * @param ctx - 宿主 Context（cordis）。
  * @param config - 行配置（cordis.patch.yml 的 config）。
@@ -330,6 +384,7 @@ export function apply(ctx: Context, config: Config = {}): void {
   const baseUrl = normalizeBaseUrl(config.baseUrl)
   const currency = normalizeCurrency(config.currency)
   const cnyPerUsd = normalizeCnyPerUsd(config.cnyPerUsd)
+  const fxUrl = normalizeBaseUrl(config.fxUrl === undefined || config.fxUrl === '' ? DEFAULT_FX_URL : config.fxUrl)
 
   // 成本显示币种与汇率（本地定制）：客户端无配置通道，经同源路由下发。
   ctx.effect(() => ctx.webServer.register({
@@ -340,6 +395,17 @@ export function apply(ctx: Context, config: Config = {}): void {
       writeJson(res, 200, { ok: true, currency, cnyPerUsd })
     },
   }), 'dsh-usage-chart: meta route')
+
+  // 实时汇率（本地定制）：浏览器直连汇率源有 CORS 与可靠性问题，经宿主代理。
+  ctx.effect(() => ctx.webServer.register({
+    kind: 'exact',
+    path: '/dsh-usage-chart/rate',
+    async handler(req: IncomingMessage, res: ServerResponse) {
+      if (!guardRequest(req, res)) return
+      const result = await fetchLiveRate(fxUrl)
+      writeJson(res, 200, result)
+    },
+  }), 'dsh-usage-chart: rate route')
 
   ctx.effect(() => ctx.webServer.register({
     kind: 'exact',

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -99,30 +99,24 @@ export function formatUsd(usd: number): string {
   return `$${usd.toFixed(2)}`
 }
 
-/** 成本显示币种（本地定制）：'usd' 官方刊例价原币，'cny' 按汇率换算显示。 */
 export type DisplayCurrency = 'usd' | 'cny'
 
-/** 默认美元 → 人民币汇率（本地定制；可用 config.cnyPerUsd 覆盖）。 */
 export const DEFAULT_CNY_PER_USD = 6.76
 
-/** 规范化显示币种配置。 */
 export function normalizeCurrency(value: string | undefined): DisplayCurrency {
   return value === 'cny' ? 'cny' : 'usd'
 }
 
-/** 规范化汇率配置：必须为正的有限数值，否则回退默认值。 */
 export function normalizeCnyPerUsd(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0
     ? value
     : DEFAULT_CNY_PER_USD
 }
 
-/** 把 USD 成本换算为目标显示币种的金额。 */
 export function toDisplayAmount(usd: number, currency: DisplayCurrency, cnyPerUsd: number): number {
   return currency === 'cny' ? usd * cnyPerUsd : usd
 }
 
-/** 按显示币种格式化金额：CNY 用 ¥，USD 用 $（精度规则与 formatUsd 一致）。 */
 export function formatMoney(usd: number, currency: DisplayCurrency, cnyPerUsd: number): string {
   const amount = toDisplayAmount(usd, currency, cnyPerUsd)
   const symbol = currency === 'cny' ? '¥' : '$'
@@ -132,7 +126,6 @@ export function formatMoney(usd: number, currency: DisplayCurrency, cnyPerUsd: n
   return `${symbol}${amount.toFixed(2)}`
 }
 
-/** 刊例价（USD / 1M）换算为目标币种后的数字文本（用于价格说明）。 */
 export function formatPricePerM(usd: number, currency: DisplayCurrency, cnyPerUsd: number): string {
   const amount = toDisplayAmount(usd, currency, cnyPerUsd)
   if (currency === 'usd') return String(usd)

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -98,3 +98,44 @@ export function formatUsd(usd: number): string {
   if (usd < 100) return `$${usd.toFixed(3)}`
   return `$${usd.toFixed(2)}`
 }
+
+/** 成本显示币种（本地定制）：'usd' 官方刊例价原币，'cny' 按汇率换算显示。 */
+export type DisplayCurrency = 'usd' | 'cny'
+
+/** 默认美元 → 人民币汇率（本地定制；可用 config.cnyPerUsd 覆盖）。 */
+export const DEFAULT_CNY_PER_USD = 6.76
+
+/** 规范化显示币种配置。 */
+export function normalizeCurrency(value: string | undefined): DisplayCurrency {
+  return value === 'cny' ? 'cny' : 'usd'
+}
+
+/** 规范化汇率配置：必须为正的有限数值，否则回退默认值。 */
+export function normalizeCnyPerUsd(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_CNY_PER_USD
+}
+
+/** 把 USD 成本换算为目标显示币种的金额。 */
+export function toDisplayAmount(usd: number, currency: DisplayCurrency, cnyPerUsd: number): number {
+  return currency === 'cny' ? usd * cnyPerUsd : usd
+}
+
+/** 按显示币种格式化金额：CNY 用 ¥，USD 用 $（精度规则与 formatUsd 一致）。 */
+export function formatMoney(usd: number, currency: DisplayCurrency, cnyPerUsd: number): string {
+  const amount = toDisplayAmount(usd, currency, cnyPerUsd)
+  const symbol = currency === 'cny' ? '¥' : '$'
+  if (!Number.isFinite(amount) || amount <= 0) return `${symbol}0`
+  if (amount < 0.01) return `${symbol}${amount.toFixed(4)}`
+  if (amount < 100) return `${symbol}${amount.toFixed(3)}`
+  return `${symbol}${amount.toFixed(2)}`
+}
+
+/** 刊例价（USD / 1M）换算为目标币种后的数字文本（用于价格说明）。 */
+export function formatPricePerM(usd: number, currency: DisplayCurrency, cnyPerUsd: number): string {
+  const amount = toDisplayAmount(usd, currency, cnyPerUsd)
+  if (currency === 'usd') return String(usd)
+  if (amount < 0.1) return amount.toFixed(4)
+  return amount.toFixed(3)
+}

--- a/tests/core.test.mjs
+++ b/tests/core.test.mjs
@@ -197,3 +197,47 @@ test('mounted /dsh-usage-chart/meta route serves display-currency defaults and h
   await defaults.handler({ method: 'POST', url: '/dsh-usage-chart/meta', headers: { host: 'localhost:3000' } }, methodResponse)
   assert.equal(methodResponse.status, 405)
 })
+
+test('mounted /dsh-usage-chart/rate route parses the FX source and reports failures', async () => {
+  const originalFetch = globalThis.fetch
+  const route = mountedRoutes().get('/dsh-usage-chart/rate')
+  const sameOrigin = { host: 'localhost:3000', origin: 'http://localhost:3000', 'sec-fetch-site': 'same-origin' }
+  try {
+    globalThis.fetch = async () => ({ ok: true, json: async () => ({ result: 'success', rates: { CNY: 6.77 } }) })
+    const okResponse = responseRecorder()
+    await route.handler({ method: 'GET', url: '/dsh-usage-chart/rate', headers: { ...sameOrigin } }, okResponse)
+    assert.equal(okResponse.status, 200)
+    const okBody = JSON.parse(okResponse.body)
+    assert.equal(okBody.ok, true)
+    assert.equal(okBody.rate, 6.77)
+    assert.equal(typeof okBody.fetchedAt, 'number')
+
+    globalThis.fetch = async () => ({ ok: true, json: async () => ({ rates: {} }) })
+    const badResponse = responseRecorder()
+    await route.handler({ method: 'GET', url: '/dsh-usage-chart/rate', headers: { ...sameOrigin } }, badResponse)
+    const badBody = JSON.parse(badResponse.body)
+    assert.equal(badBody.ok, false)
+    assert.equal(badBody.reason, 'bad-response')
+
+    globalThis.fetch = async () => ({ ok: true, json: async () => ({ rates: { CNY: -1 } }) })
+    const negativeResponse = responseRecorder()
+    await route.handler({ method: 'GET', url: '/dsh-usage-chart/rate', headers: { ...sameOrigin } }, negativeResponse)
+    assert.equal(JSON.parse(negativeResponse.body).reason, 'bad-response')
+
+    globalThis.fetch = async () => ({ ok: false, json: async () => ({}) })
+    const httpResponse = responseRecorder()
+    await route.handler({ method: 'GET', url: '/dsh-usage-chart/rate', headers: { ...sameOrigin } }, httpResponse)
+    assert.equal(JSON.parse(httpResponse.body).reason, 'request-failed')
+
+    globalThis.fetch = async () => { throw new Error('network down') }
+    const throwResponse = responseRecorder()
+    await route.handler({ method: 'GET', url: '/dsh-usage-chart/rate', headers: { ...sameOrigin } }, throwResponse)
+    assert.equal(JSON.parse(throwResponse.body).reason, 'request-failed')
+
+    const methodResponse = responseRecorder()
+    await route.handler({ method: 'POST', url: '/dsh-usage-chart/rate', headers: { host: 'localhost:3000' } }, methodResponse)
+    assert.equal(methodResponse.status, 405)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})

--- a/tests/core.test.mjs
+++ b/tests/core.test.mjs
@@ -2,13 +2,19 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  DEFAULT_CNY_PER_USD,
   PRICING,
   apply,
   cacheHitPercent,
   estimateCost,
   foldTurnUsage,
+  formatMoney,
+  formatPricePerM,
   isTrustedRequest,
   normalizeBaseUrl,
+  normalizeCnyPerUsd,
+  normalizeCurrency,
+  toDisplayAmount,
 } from '../lib/index.js'
 
 function responseRecorder() {
@@ -22,7 +28,7 @@ function responseRecorder() {
   }
 }
 
-function mountedRoutes(events = []) {
+function mountedRoutes(events = [], config = {}) {
   const routes = new Map()
   apply({
     effect(setup) { setup() },
@@ -33,7 +39,7 @@ function mountedRoutes(events = []) {
     sessions: {
       get(id) { return id === 'session-test' ? { id, events } : undefined },
     },
-  })
+  }, config)
   return routes
 }
 
@@ -143,4 +149,51 @@ test('balance route reports no-api-key when no key is configured anywhere', asyn
   assert.equal(recorder.status, 200)
   assert.equal(body.apiKeyConfigured, false)
   assert.equal(body.reason, 'no-api-key')
+})
+
+test('display-currency helpers convert and format USD amounts', () => {
+  assert.equal(normalizeCurrency(undefined), 'usd')
+  assert.equal(normalizeCurrency('usd'), 'usd')
+  assert.equal(normalizeCurrency('cny'), 'cny')
+  assert.equal(normalizeCurrency('eur'), 'usd')
+  assert.equal(normalizeCnyPerUsd(undefined), DEFAULT_CNY_PER_USD)
+  assert.equal(normalizeCnyPerUsd(7.1), 7.1)
+  assert.equal(normalizeCnyPerUsd(-1), DEFAULT_CNY_PER_USD)
+  assert.equal(normalizeCnyPerUsd('x'), DEFAULT_CNY_PER_USD)
+
+  assert.equal(toDisplayAmount(0.058, 'usd', 6.76), 0.058)
+  assert.ok(Math.abs(toDisplayAmount(0.058, 'cny', 6.76) - 0.058 * 6.76) < 1e-12)
+
+  assert.equal(formatMoney(0, 'usd', 6.76), '$0')
+  assert.equal(formatMoney(0.058, 'usd', 6.76), '$0.058')
+  assert.equal(formatMoney(0.058, 'cny', 6.76), '¥0.392')
+  assert.equal(formatMoney(1, 'cny', 6.76), '¥6.760')
+  assert.equal(formatMoney(123, 'usd', 6.76), '$123.00')
+
+  assert.equal(formatPricePerM(0.14, 'usd', 6.76), '0.14')
+  assert.equal(formatPricePerM(0.14, 'cny', 6.76), '0.946')
+  assert.equal(formatPricePerM(0.0028, 'cny', 6.76), '0.0189')
+  assert.equal(formatPricePerM(0.28, 'cny', 6.76), '1.893')
+})
+
+test('mounted /dsh-usage-chart/meta route serves display-currency defaults and honors config', async () => {
+  const defaults = mountedRoutes().get('/dsh-usage-chart/meta')
+  const defaultResponse = responseRecorder()
+  await defaults.handler({ method: 'GET', url: '/dsh-usage-chart/meta', headers: { host: 'localhost:3000', origin: 'http://localhost:3000', 'sec-fetch-site': 'same-origin' } }, defaultResponse)
+  assert.equal(defaultResponse.status, 200)
+  assert.deepEqual(JSON.parse(defaultResponse.body), { ok: true, currency: 'usd', cnyPerUsd: DEFAULT_CNY_PER_USD })
+
+  const custom = mountedRoutes([], { currency: 'cny', cnyPerUsd: 7.1 }).get('/dsh-usage-chart/meta')
+  const customResponse = responseRecorder()
+  await custom.handler({ method: 'GET', url: '/dsh-usage-chart/meta', headers: { host: 'localhost:3000', origin: 'http://localhost:3000', 'sec-fetch-site': 'same-origin' } }, customResponse)
+  assert.deepEqual(JSON.parse(customResponse.body), { ok: true, currency: 'cny', cnyPerUsd: 7.1 })
+
+  const invalid = mountedRoutes([], { currency: 'eur', cnyPerUsd: -5 }).get('/dsh-usage-chart/meta')
+  const invalidResponse = responseRecorder()
+  await invalid.handler({ method: 'GET', url: '/dsh-usage-chart/meta', headers: { host: 'localhost:3000', origin: 'http://localhost:3000', 'sec-fetch-site': 'same-origin' } }, invalidResponse)
+  assert.deepEqual(JSON.parse(invalidResponse.body), { ok: true, currency: 'usd', cnyPerUsd: DEFAULT_CNY_PER_USD })
+
+  const methodResponse = responseRecorder()
+  await defaults.handler({ method: 'POST', url: '/dsh-usage-chart/meta', headers: { host: 'localhost:3000' } }, methodResponse)
+  assert.equal(methodResponse.status, 405)
 })

--- a/types/cordis.d.ts
+++ b/types/cordis.d.ts
@@ -31,10 +31,6 @@ export interface SlotRegisterOptions {
 /** ui-slots 的 SlotRegistry 服务（register 返回卸载函数）。 */
 export interface SlotRegistry {
   register(options: SlotRegisterOptions, component: unknown): () => void
-  /**
-   * 等待槽位声明后再执行注册回调：已声明时同步运行；未声明时在声明提交后运行，
-   * 声明坍塌时释放回调效果、再次声明时重新运行。返回值是幂等的 disposer。
-   */
   inject(key: string, callback: () => (() => void) | void): () => void
 }
 

--- a/types/cordis.d.ts
+++ b/types/cordis.d.ts
@@ -31,6 +31,11 @@ export interface SlotRegisterOptions {
 /** ui-slots 的 SlotRegistry 服务（register 返回卸载函数）。 */
 export interface SlotRegistry {
   register(options: SlotRegisterOptions, component: unknown): () => void
+  /**
+   * 等待槽位声明后再执行注册回调：已声明时同步运行；未声明时在声明提交后运行，
+   * 声明坍塌时释放回调效果、再次声明时重新运行。返回值是幂等的 disposer。
+   */
+  inject(key: string, callback: () => (() => void) | void): () => void
 }
 
 /** dsh-client-locale 的 locale 服务（本插件用到的面：订阅活动语言）。 */


### PR DESCRIPTION
## What

- Cost estimates can now be displayed in CNY: new `config.currency`
  (`'usd'` default / `'cny'`) and `config.cnyPerUsd` exchange rate
  (default `6.76`). Prices are converted from the official USD list price.
- A **USD/CNY toggle** in the cost-estimate section: switching updates the
  composer indicator, all dashboard cost figures, and the price note
  immediately; the choice is remembered in the browser (`localStorage`).
- A **rate-refresh control** in the cost-estimate section: it fetches the
  latest USD→CNY rate through a new same-origin host proxy route
  (`/dsh-usage-chart/rate`; source configurable via `config.fxUrl`, default
  open.er-api.com) and re-estimates immediately; failures keep the previous
  rate with an inline note. A new `/dsh-usage-chart/meta` route serves the
  display-currency config to the client.

## Fixed

- Client slot registration now uses `ctx.slots.inject('conversation.composer.dock', …)`.
  Direct `register` depends on loader application order and throws
  `slot "…" is not declared` at boot when other plugins change that order.

## Verification

- `npm run verify`: typecheck passes; 14/14 tests pass (new coverage for
  currency conversion/formatting helpers and the `meta`/`rate` routes).
- `scripts/verify-render.mjs` passes (light/dark theme, zh/en UI, chart and
  panel assertions all green; zero console errors); `probe-panel.mjs` and
  `probe-popover.mjs` pass.
- Probe scripts updated: the panel now has two `duc-view-toggle` groups
  (currency / chart view), so the chart-mode buttons are located by
  `aria-label` instead of position.
- CHANGELOG updated under Unreleased.
